### PR TITLE
Swap spellchecker and use multiple check runs

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,17 +59,6 @@ module.exports = app => {
     const generator = new OutputGenerator(fileMap, config, context.log)
 
     // Generate the output
-    const output = generator.generate()
-    context.log.debug('Generator output', output)
-
-    // Let em know whats up by creating a Check Run
-    return context.github.checks.create(context.repo({
-      name: 'prosebot',
-      head_sha: context.payload.check_suite.head_sha,
-      head_branch: context.payload.check_suite.head_branch,
-      completed_at: new Date().toISOString(),
-      conclusion: generator.conclusion,
-      output
-    }))
+    return generator.buildAllResults(context)
   })
 }

--- a/lib/output-generator.js
+++ b/lib/output-generator.js
@@ -36,17 +36,19 @@ class OutputGenerator {
    * @returns {string} - Either `success` or `failure`
    */
   reachConclusion (results) {
-    let success = true
+    let conclusion = 'success'
 
-    for (const output of results) {
-      const reasons = output[1]
+    for (const [, reasons] of results) {
       if (reasons.length) {
-        success = false
-        break
+        if (reasons.some(r => r.annotation_level === 'failure')) {
+          conclusion = 'failure'
+          break
+        } else {
+          conclusion = 'neutral'
+        }
       }
     }
 
-    const conclusion = success ? 'success' : 'failure'
     this.conclusion = conclusion
     return conclusion
   }
@@ -105,13 +107,11 @@ class OutputGenerator {
    * Gets the results of all the enabled providers
    * @returns {Map<string, Result[]>}
    */
-  buildAllResults () {
-    const fullMap = new Map()
-
+  buildAllResults (context) {
     // Just the providers that have been enabled, as per the repo's config file
     const enabledProviders = Object.keys(providers).filter(key => Boolean(this.config[key]))
 
-    enabledProviders.forEach(key => {
+    return Promise.all(enabledProviders.map(async key => {
       const Provider = providers[key]
       const provider = new Provider(this.map)
 
@@ -119,40 +119,23 @@ class OutputGenerator {
       const results = provider.buildResults()
       this.logger.debug(key, results)
 
-      // Merge the results of each provider into the full map
-      for (const [filename, reasons] of results) {
-        if (!reasons.length) continue
+      const conclusion = this.reachConclusion(results)
+      const summary = this.buildSummary(conclusion, results)
 
-        if (fullMap.has(filename)) {
-          // If the fullMap already has results for this file, combine them
-          const existing = fullMap.get(filename)
-          this.logger.debug(`Adding to ${filename}`, reasons)
-          fullMap.set(filename, [...existing, ...reasons])
-        } else {
-          // Otherwise start a new entry
-          this.logger.debug(`Setting ${filename}`, reasons)
-          fullMap.set(filename, reasons)
+      // Let em know whats up by creating a Check Run
+      return context.github.checks.create(context.repo({
+        name: provider.constructor.name,
+        head_sha: context.payload.check_suite.head_sha,
+        head_branch: context.payload.check_suite.head_branch,
+        completed_at: new Date().toISOString(),
+        conclusion,
+        output: {
+          title: conclusion === 'success' ? 'No issues have been found!' : `${provider.constructor.name} has some suggestions!`,
+          summary,
+          annotations: this.buildAnnotations(results)
         }
-      }
-    })
-
-    this.logger.debug('Fullmap', fullMap)
-    return fullMap
-  }
-
-  /**
-   * @returns {OutputReturn}
-   */
-  generate () {
-    const results = this.buildAllResults()
-    const conclusion = this.reachConclusion(results)
-    const summary = this.buildSummary(conclusion, results)
-
-    return {
-      title: conclusion === 'success' ? 'No issues have been found!' : 'See suggestions below.',
-      summary,
-      annotations: this.buildAnnotations(results)
-    }
+      }))
+    }))
   }
 }
 

--- a/lib/providers/spellcheck.js
+++ b/lib/providers/spellcheck.js
@@ -1,5 +1,7 @@
 const spellchecker = require('spellchecker')
 const findLineColumn = require('../find-line-column')
+const markdown = require('markdown-spellcheck').default
+markdown.spellcheck.initialise()
 
 class SpellCheck {
   /**
@@ -11,8 +13,8 @@ class SpellCheck {
     this.spellchecker = spellchecker
   }
 
-  buildReasonString (contents, start, end) {
-    const word = contents.substring(start, end)
+  buildReasonString (word) {
+    // Use `spellchecker` for corrections because `markdown-spellcheck`'s API does export properly
     const corrections = this.spellchecker.getCorrectionsForMisspelling(word).slice(0, 6)
     return `"${word}" is misspelled. ${corrections.length ? `How about: ${corrections.join(', ')}` : ''}`
   }
@@ -24,8 +26,8 @@ class SpellCheck {
    */
   serializeReasons (reasons, contents) {
     return reasons.map(reason => {
-      const { line } = findLineColumn(contents, reason.start)
-      return { line, reason: this.buildReasonString(contents, reason.start, reason.end) }
+      const { line } = findLineColumn(contents, reason.index)
+      return { line, reason: this.buildReasonString(reason.word) }
     })
   }
 
@@ -38,7 +40,7 @@ class SpellCheck {
     const results = new Map()
 
     for (const [filename, contents] of this.contentMap) {
-      const reasons = this.spellchecker.checkSpelling(contents)
+      const reasons = markdown.spell(contents)
       results.set(filename, this.serializeReasons(reasons, contents))
     }
 

--- a/lib/providers/spellcheck.js
+++ b/lib/providers/spellcheck.js
@@ -1,7 +1,6 @@
 const spellchecker = require('spellchecker')
 const findLineColumn = require('../find-line-column')
 const markdown = require('markdown-spellcheck').default
-markdown.spellcheck.initialise()
 
 class SpellCheck {
   /**

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "alex": "^6.0.0",
+    "markdown-spellcheck": "^1.3.1",
     "probot": "^7.2.0",
     "remove-markdown": "^0.3.0",
     "spellchecker": "^3.5.0",

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,76 +1,116 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`prosebot creates a \`failing\` check run 1`] = `
-Object {
-  "conclusion": "failure",
-  "head_branch": "pr",
-  "head_sha": "296e2e88379d2ca5f211bac7bc25f78dc879236c",
-  "name": "prosebot",
-  "output": Object {
-    "annotations": Array [
-      Object {
-        "annotation_level": "warning",
-        "end_line": 3,
-        "message": "\\"So\\" adds no meaning",
-        "path": "added.md",
-        "start_line": 3,
-      },
-      Object {
-        "annotation_level": "warning",
-        "end_line": 5,
-        "message": "\\"So\\" adds no meaning",
-        "path": "added.md",
-        "start_line": 5,
-      },
-      Object {
-        "annotation_level": "warning",
-        "end_line": 3,
-        "message": "Don’t use “dope”, it’s profane",
-        "path": "added.md",
-        "start_line": 3,
-      },
-      Object {
-        "annotation_level": "warning",
-        "end_line": 7,
-        "message": "\`his\` may be insensitive, use \`their\`, \`theirs\`, \`them\` instead",
-        "path": "added.md",
-        "start_line": 7,
-      },
-      Object {
-        "annotation_level": "warning",
-        "end_line": 3,
-        "message": "\\"So\\" adds no meaning",
-        "path": "modified.md",
-        "start_line": 3,
-      },
-      Object {
-        "annotation_level": "warning",
-        "end_line": 5,
-        "message": "\\"So\\" adds no meaning",
-        "path": "modified.md",
-        "start_line": 5,
-      },
-      Object {
-        "annotation_level": "warning",
-        "end_line": 3,
-        "message": "Don’t use “dope”, it’s profane",
-        "path": "modified.md",
-        "start_line": 3,
-      },
-      Object {
-        "annotation_level": "warning",
-        "end_line": 7,
-        "message": "\`his\` may be insensitive, use \`their\`, \`theirs\`, \`them\` instead",
-        "path": "modified.md",
-        "start_line": 7,
-      },
-    ],
-    "summary": "**8 suggestions** have been found in **2 files**.",
-    "title": "See suggestions below.",
+exports[`prosebot creates a \`neutral\` check run 1`] = `
+Array [
+  "neutral",
+  "neutral",
+  "success",
+]
+`;
+
+exports[`prosebot creates a \`neutral\` check run 2`] = `
+Array [
+  Object {
+    "completed_at": 123,
+    "conclusion": "neutral",
+    "head_branch": "pr",
+    "head_sha": "296e2e88379d2ca5f211bac7bc25f78dc879236c",
+    "name": "WriteGood",
+    "output": Object {
+      "annotations": Array [
+        Object {
+          "annotation_level": "warning",
+          "end_line": 3,
+          "message": "\\"So\\" adds no meaning",
+          "path": "added.md",
+          "start_line": 3,
+        },
+        Object {
+          "annotation_level": "warning",
+          "end_line": 5,
+          "message": "\\"So\\" adds no meaning",
+          "path": "added.md",
+          "start_line": 5,
+        },
+        Object {
+          "annotation_level": "warning",
+          "end_line": 3,
+          "message": "\\"So\\" adds no meaning",
+          "path": "modified.md",
+          "start_line": 3,
+        },
+        Object {
+          "annotation_level": "warning",
+          "end_line": 5,
+          "message": "\\"So\\" adds no meaning",
+          "path": "modified.md",
+          "start_line": 5,
+        },
+      ],
+      "summary": "**4 suggestions** have been found in **2 files**.",
+      "title": "WriteGood has some suggestions!",
+    },
+    "owner": "JasonEtco",
+    "repo": "tests",
   },
-  "owner": "JasonEtco",
-  "repo": "tests",
-}
+  Object {
+    "completed_at": 123,
+    "conclusion": "neutral",
+    "head_branch": "pr",
+    "head_sha": "296e2e88379d2ca5f211bac7bc25f78dc879236c",
+    "name": "Alex",
+    "output": Object {
+      "annotations": Array [
+        Object {
+          "annotation_level": "warning",
+          "end_line": 3,
+          "message": "Don’t use “dope”, it’s profane",
+          "path": "added.md",
+          "start_line": 3,
+        },
+        Object {
+          "annotation_level": "warning",
+          "end_line": 7,
+          "message": "\`his\` may be insensitive, use \`their\`, \`theirs\`, \`them\` instead",
+          "path": "added.md",
+          "start_line": 7,
+        },
+        Object {
+          "annotation_level": "warning",
+          "end_line": 3,
+          "message": "Don’t use “dope”, it’s profane",
+          "path": "modified.md",
+          "start_line": 3,
+        },
+        Object {
+          "annotation_level": "warning",
+          "end_line": 7,
+          "message": "\`his\` may be insensitive, use \`their\`, \`theirs\`, \`them\` instead",
+          "path": "modified.md",
+          "start_line": 7,
+        },
+      ],
+      "summary": "**4 suggestions** have been found in **2 files**.",
+      "title": "Alex has some suggestions!",
+    },
+    "owner": "JasonEtco",
+    "repo": "tests",
+  },
+  Object {
+    "completed_at": 123,
+    "conclusion": "success",
+    "head_branch": "pr",
+    "head_sha": "296e2e88379d2ca5f211bac7bc25f78dc879236c",
+    "name": "SpellCheck",
+    "output": Object {
+      "annotations": Array [],
+      "summary": "No issues have been found, great job!",
+      "title": "No issues have been found!",
+    },
+    "owner": "JasonEtco",
+    "repo": "tests",
+  },
+]
 `;
 
 exports[`prosebot creates a \`neutral\` check run if there are no files to check 1`] = `
@@ -88,18 +128,57 @@ Object {
 }
 `;
 
-exports[`prosebot creates a \`success\` check run 1`] = `
-Object {
-  "conclusion": "success",
-  "head_branch": "pr",
-  "head_sha": "296e2e88379d2ca5f211bac7bc25f78dc879236c",
-  "name": "prosebot",
-  "output": Object {
-    "annotations": Array [],
-    "summary": "No issues have been found, great job!",
-    "title": "No issues have been found!",
+exports[`prosebot creates all \`success\` check runs 1`] = `
+Array [
+  "success",
+  "success",
+  "success",
+]
+`;
+
+exports[`prosebot creates all \`success\` check runs 2`] = `
+Array [
+  Object {
+    "completed_at": 123,
+    "conclusion": "success",
+    "head_branch": "pr",
+    "head_sha": "296e2e88379d2ca5f211bac7bc25f78dc879236c",
+    "name": "WriteGood",
+    "output": Object {
+      "annotations": Array [],
+      "summary": "No issues have been found, great job!",
+      "title": "No issues have been found!",
+    },
+    "owner": "JasonEtco",
+    "repo": "tests",
   },
-  "owner": "JasonEtco",
-  "repo": "tests",
-}
+  Object {
+    "completed_at": 123,
+    "conclusion": "success",
+    "head_branch": "pr",
+    "head_sha": "296e2e88379d2ca5f211bac7bc25f78dc879236c",
+    "name": "Alex",
+    "output": Object {
+      "annotations": Array [],
+      "summary": "No issues have been found, great job!",
+      "title": "No issues have been found!",
+    },
+    "owner": "JasonEtco",
+    "repo": "tests",
+  },
+  Object {
+    "completed_at": 123,
+    "conclusion": "success",
+    "head_branch": "pr",
+    "head_sha": "296e2e88379d2ca5f211bac7bc25f78dc879236c",
+    "name": "SpellCheck",
+    "output": Object {
+      "annotations": Array [],
+      "summary": "No issues have been found, great job!",
+      "title": "No issues have been found!",
+    },
+    "owner": "JasonEtco",
+    "repo": "tests",
+  },
+]
 `;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -70,18 +70,21 @@ describe('prosebot', () => {
     expect(call).toMatchSnapshot()
   })
 
-  it('creates a `success` check run', async () => {
+  it('creates all `success` check runs', async () => {
     await app.receive(event)
     expect(github.checks.create).toHaveBeenCalled()
 
-    const call = github.checks.create.mock.calls[0][0]
-    expect(call.conclusion).toBe('success')
+    const calls = github.checks.create.mock.calls
+    expect(calls.map(call => call[0].conclusion)).toMatchSnapshot()
 
-    delete call.completed_at
-    expect(call).toMatchSnapshot()
+    const withoutTimestamps = calls.map(call => ({
+      ...call[0],
+      completed_at: 123
+    }))
+    expect(withoutTimestamps).toMatchSnapshot()
   })
 
-  it('creates a `failing` check run', async () => {
+  it('creates a `neutral` check run', async () => {
     github.repos.getContent = jest.fn(o => {
       if (o.path === '.github/prosebot.yml') throw { code: 404 } // eslint-disable-line no-throw-literal
       return Promise.resolve({ data: {
@@ -92,10 +95,13 @@ describe('prosebot', () => {
     await app.receive(event)
     expect(github.checks.create).toHaveBeenCalled()
 
-    const call = github.checks.create.mock.calls[0][0]
-    expect(call.conclusion).toBe('failure')
+    const calls = github.checks.create.mock.calls
+    expect(calls.map(call => call[0].conclusion)).toMatchSnapshot()
 
-    delete call.completed_at
-    expect(call).toMatchSnapshot()
+    const withoutTimestamps = calls.map(call => ({
+      ...call[0],
+      completed_at: 123
+    }))
+    expect(withoutTimestamps).toMatchSnapshot()
   })
 })

--- a/test/lib/__snapshots__/output-generator.test.js.snap
+++ b/test/lib/__snapshots__/output-generator.test.js.snap
@@ -5,75 +5,18 @@ Array [
   Object {
     "annotation_level": "warning",
     "end_line": 1,
-    "message": "\\"So\\" adds no meaning",
-    "path": "cats.md",
-    "start_line": 1,
-  },
-  Object {
-    "annotation_level": "warning",
-    "end_line": 1,
-    "message": "\\"was stolen\\" may be passive voice",
-    "path": "cats.md",
+    "message": "why not",
+    "path": "filename.md",
     "start_line": 1,
   },
 ]
 `;
 
-exports[`OutputGenerator #buildAnnotations skips files that have no results 1`] = `
-Array [
-  Object {
-    "annotation_level": "warning",
-    "end_line": 1,
-    "message": "\\"So\\" adds no meaning",
-    "path": "cats.md",
-    "start_line": 1,
-  },
-  Object {
-    "annotation_level": "warning",
-    "end_line": 1,
-    "message": "\\"was stolen\\" may be passive voice",
-    "path": "cats.md",
-    "start_line": 1,
-  },
-]
-`;
-
-exports[`OutputGenerator #buildSummary returns the expected string if there are suggestions 1`] = `"**2 suggestions** have been found in **1 file**."`;
+exports[`OutputGenerator #buildSummary returns the expected string if there are suggestions 1`] = `"**1 suggestion** has been found in **1 file**."`;
 
 exports[`OutputGenerator #buildSummary returns the expected string if there is just one 1`] = `"**1 suggestion** has been found in **1 file**."`;
 
 exports[`OutputGenerator #buildSummary returns the expected string with zero results 1`] = `"**0 suggestions** have been found in **0 files**."`;
-
-exports[`OutputGenerator #generate generates the expected result 1`] = `
-Object {
-  "annotations": Array [
-    Object {
-      "annotation_level": "warning",
-      "end_line": 1,
-      "message": "\\"So\\" adds no meaning",
-      "path": "cats.md",
-      "start_line": 1,
-    },
-    Object {
-      "annotation_level": "warning",
-      "end_line": 1,
-      "message": "\\"was stolen\\" may be passive voice",
-      "path": "cats.md",
-      "start_line": 1,
-    },
-  ],
-  "summary": "**2 suggestions** have been found in **1 file**.",
-  "title": "See suggestions below.",
-}
-`;
-
-exports[`OutputGenerator #generate only uses the enabled providers 1`] = `
-Object {
-  "annotations": Array [],
-  "summary": "No issues have been found, great job!",
-  "title": "No issues have been found!",
-}
-`;
 
 exports[`OutputGenerator static#removeMarkdownFromFiles removes markdown from the files and returns the expected map 1`] = `
 Map {

--- a/test/lib/output-generator.test.js
+++ b/test/lib/output-generator.test.js
@@ -32,8 +32,16 @@ describe('OutputGenerator', () => {
   })
 
   describe('#reachConclusion', () => {
-    it('returns `failure` if there are any suggestions', () => {
-      const results = generator.buildAllResults()
+    it('returns `neutral` if there are any suggestions', () => {
+      const results = new Map()
+      results.set('something.md', [{}])
+      const actual = generator.reachConclusion(results)
+      expect(actual).toBe('neutral')
+    })
+
+    it('returns `failure` if there are any failing suggestions', () => {
+      const results = new Map()
+      results.set('something.md', [{ annotation_level: 'failure' }])
       const actual = generator.reachConclusion(results)
       expect(actual).toBe('failure')
     })
@@ -89,19 +97,6 @@ describe('OutputGenerator', () => {
       const results = generator.buildAllResults()
       results.set('filename.md', [])
       const actual = generator.buildAnnotations(results)
-      expect(actual).toMatchSnapshot()
-    })
-  })
-
-  describe('#generate', () => {
-    it('generates the expected result', () => {
-      const actual = generator.generate()
-      expect(actual).toMatchSnapshot()
-    })
-
-    it('only uses the enabled providers', () => {
-      generator.config = { ...generator.config, writeGood: false }
-      const actual = generator.generate()
       expect(actual).toMatchSnapshot()
     })
   })

--- a/test/lib/output-generator.test.js
+++ b/test/lib/output-generator.test.js
@@ -66,7 +66,8 @@ describe('OutputGenerator', () => {
     })
 
     it('returns the expected string if there are suggestions', () => {
-      const results = generator.buildAllResults()
+      const results = new Map()
+      results.set('filename.md', [{ line: 1, reason: 'why not' }])
       const actual = generator.buildSummary('failure', results)
       expect(actual).toMatchSnapshot()
     })
@@ -88,14 +89,8 @@ describe('OutputGenerator', () => {
 
   describe('#buildAnnotations', () => {
     it('returns the expected array of annotations', () => {
-      const results = generator.buildAllResults()
-      const actual = generator.buildAnnotations(results)
-      expect(actual).toMatchSnapshot()
-    })
-
-    it('skips files that have no results', () => {
-      const results = generator.buildAllResults()
-      results.set('filename.md', [])
+      const results = new Map()
+      results.set('filename.md', [{ line: 1, reason: 'why not' }])
       const actual = generator.buildAnnotations(results)
       expect(actual).toMatchSnapshot()
     })

--- a/test/lib/providers/__snapshots__/spellcheck.test.js.snap
+++ b/test/lib/providers/__snapshots__/spellcheck.test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SpellCheck provider #buildReasonString returns the expected string with some corrections 1`] = `
+Array [
+  Object {
+    "line": 1,
+    "reason": "\\"iam\\" is misspelled. How about: something, anotherword",
+  },
+  Object {
+    "line": 1,
+    "reason": "\\"wurd\\" is misspelled. How about: something, anotherword",
+  },
+]
+`;
+
 exports[`SpellCheck provider #buildReasonString returns the expected string with zero possible corrections 1`] = `
 Array [
   Object {

--- a/test/lib/providers/__snapshots__/spellcheck.test.js.snap
+++ b/test/lib/providers/__snapshots__/spellcheck.test.js.snap
@@ -12,3 +12,35 @@ Array [
   },
 ]
 `;
+
+exports[`SpellCheck provider #buildResults returns the expected result 1`] = `
+Map {
+  "filename.md" => Array [
+    Object {
+      "line": 1,
+      "reason": "\\"iam\\" is misspelled. ",
+    },
+    Object {
+      "line": 1,
+      "reason": "\\"wurd\\" is misspelled. ",
+    },
+  ],
+  "anotherfile.md" => Array [
+    Object {
+      "line": 1,
+      "reason": "\\"Tenis\\" is misspelled. ",
+    },
+    Object {
+      "line": 1,
+      "reason": "\\"sporq\\" is misspelled. ",
+    },
+  ],
+  "gibberish.md" => Array [
+    Object {
+      "line": 1,
+      "reason": "\\"AbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdf\\" is misspelled. ",
+    },
+  ],
+  "technical-doc.md" => Array [],
+}
+`;

--- a/test/lib/providers/spellcheck.test.js
+++ b/test/lib/providers/spellcheck.test.js
@@ -9,7 +9,8 @@ describe('SpellCheck provider', () => {
     const obj = {
       'filename.md': 'iam not a wurd',
       'anotherfile.md': 'Tenis is a fun sporq',
-      'gibberish.md': 'AbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdf'
+      'gibberish.md': 'AbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdfAbsdfsdalkjhfthjsdfsdf',
+      'technical-doc.md': 'This is a `config.yml` file. Here is some code: ```js\nconsole.log(pizza_slice)\n```'
     }
 
     for (const key in obj) {
@@ -17,21 +18,16 @@ describe('SpellCheck provider', () => {
     }
 
     provider = new SpellCheck(map)
+
+    // Don't return any corrections, these can change depending on
+    // the environment so snapshots will always fail.
+    provider.spellchecker.getCorrectionsForMisspelling = jest.fn(() => ([]))
   })
 
   describe('#buildResults', () => {
     it('returns the expected result', () => {
       const actual = provider.buildResults()
-
-      // Spellcheck bounces the corrections around, so we can't snapshot test
-      expect(actual.size).toBe(3)
-
-      // Ensure we include a corrections string
-      expect(actual.get('filename.md').some(a => a.reason.includes('How about:'))).toBe(true)
-      expect(actual.get('anotherfile.md').some(a => a.reason.includes('How about:'))).toBe(true)
-
-      // Gibberish one, shouldn't include any corrections
-      expect(actual.get('gibberish.md').some(a => a.reason.includes('How about:'))).toBe(false)
+      expect(actual).toMatchSnapshot()
     })
   })
 

--- a/test/lib/providers/spellcheck.test.js
+++ b/test/lib/providers/spellcheck.test.js
@@ -37,5 +37,11 @@ describe('SpellCheck provider', () => {
       const actual = provider.buildResults()
       expect(actual.get('filename.md')).toMatchSnapshot()
     })
+
+    it('returns the expected string with some corrections', () => {
+      provider.spellchecker.getCorrectionsForMisspelling = jest.fn(() => (['something', 'anotherword']))
+      const actual = provider.buildResults()
+      expect(actual.get('filename.md')).toMatchSnapshot()
+    })
   })
 })


### PR DESCRIPTION
Swaps the Spellchecker module for one that's a little more code-friendly; this will prevent erroneous "errors" for things like code blocks, file names, etc.

Also changes the way the app reports check runs to go from one check run to a separate check run per provider, all within one check suite. See the before/after:

<img width="322" alt="image" src="https://user-images.githubusercontent.com/10660468/47956350-79111680-df79-11e8-85d2-0b805655719e.png">

I've also tweaked how the app calculates conclusions - everything will be a `neutral` conclusion if there's at least one suggestion, or a `failure` of there is at least one annotation with `annotation_level: failure`. We'll see how this works out - I didn't want to say "anything with one spelling error is a failed build" because spell checkers aren't perfect, especially in technical documentation.
