### PR TITLE
Add started at

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const defaultConfig = require('./lib/default-config')
  */
 module.exports = app => {
   app.on('check_suite.requested', async context => {
+    const timeStart = new Date()
+
     // Only act on one pull request (for now)
     const pr = context.payload.check_suite.pull_requests[0]
     if (!pr) return
@@ -30,6 +32,7 @@ module.exports = app => {
         name: 'prosebot',
         head_sha: context.payload.check_suite.head_sha,
         head_branch: context.payload.check_suite.head_branch,
+        started_at: timeStart,
         completed_at: new Date().toISOString(),
         conclusion: 'neutral',
         output: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,6 +66,7 @@ describe('prosebot', () => {
     const call = github.checks.create.mock.calls[0][0]
     expect(call.conclusion).toBe('neutral')
 
+    delete call.started_at
     delete call.completed_at
     expect(call).toMatchSnapshot()
   })


### PR DESCRIPTION
This prevents GitHub from reporting:
`ran ... days ago in less than 5 seconds`
when in fact GitHub is thinking "it ran in negative 1 minute".