### PR TITLE
make prosebot running on contributor prs

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -133,4 +133,4 @@ default_permissions:
 
 # Set to true when your GitHub App is available to the public or false when it is only accessible to the owner of the app.
 # Default: true
-public: false
+public: true


### PR DESCRIPTION
In my repo https://github.com/rxjs-blog/blog I noticed that prosebot is only running on prs I created. I'm not professional with github apps, but it seems like the privatep roperty in the app manifest is causing this behavior